### PR TITLE
git_branch() file_exists continuity

### DIFF
--- a/wppt-emailer.php
+++ b/wppt-emailer.php
@@ -217,7 +217,7 @@
 			if( !file_exists( plugin_dir_path(__FILE__).'.git'.DIRECTORY_SEPARATOR.'HEAD' ) ) {
 				return false; 
 			} else { 
-				return trim(substr(file_get_contents(dirname(__FILE__).DIRECTORY_SEPARATOR.'.git'.DIRECTORY_SEPARATOR.'HEAD'), 16));
+				return trim(substr(file_get_contents(plugin_dir_path(__FILE__).'.git'.DIRECTORY_SEPARATOR.'HEAD'), 16));
 			}
 		}
 	}


### PR DESCRIPTION
Spotted two versions of code to access filename (generated by plugin function name conflict resolution).

Should have no noticable difference., tidied purely for OCD consistency.